### PR TITLE
feat(identity): 조직 및 사용자 관련 엔티티/매핑 구조 개선 및 명확화

### DIFF
--- a/backend/src/domain/identity/base.py
+++ b/backend/src/domain/identity/base.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+from sqlalchemy import String, CHAR
+from sqlalchemy.orm import Mapped, mapped_column
+
+from domain.common.base import Base, IdMixin, TimestampMixin, AuditMixin
+
+class IdentityStatusMixin:
+    """상태 관리를 위한 Mixin - CHAR(1) 타입 사용"""
+    use_yn: Mapped[str] = mapped_column(CHAR(1), default='Y', nullable=False)
+    delete_yn: Mapped[str] = mapped_column(CHAR(1), default='N', nullable=False)
+
+class IdentityBaseEntity(Base, IdMixin, IdentityStatusMixin, TimestampMixin, AuditMixin):
+    """Identity 도메인의 기본 엔티티"""
+    __abstract__ = True
+
+    def mark_deleted(self, deleted_by: UUID) -> None:
+        """엔티티를 삭제 처리합니다."""
+        self.delete_yn = 'Y'
+        self.use_yn = 'N'
+        self.deleted_at = datetime.utcnow()
+        self.deleted_by = deleted_by
+        self.updated_at = datetime.utcnow()
+        self.updated_by = deleted_by
+
+class OrganizationBaseEntity(IdentityBaseEntity):
+    """조직 관련 엔티티의 기본 클래스"""
+    __abstract__ = True
+
+    name: Mapped[str] = mapped_column(String(100), nullable=False) 

--- a/backend/src/domain/identity/entities/__init__.py
+++ b/backend/src/domain/identity/entities/__init__.py
@@ -1,0 +1,25 @@
+from .user import User
+from .company import Company, CompanyRegistrationRequest
+from .organization import Department, Team, Position, Responsibility
+from .mappings import (
+    CompanyUser,
+    CompanyDepartment,
+    CompanyTeam,
+    CompanyPosition,
+    CompanyResponsibility
+)
+
+__all__ = [
+    'User',
+    'Company',
+    'CompanyRegistrationRequest',
+    'Department',
+    'Team',
+    'Position',
+    'Responsibility',
+    'CompanyUser',
+    'CompanyDepartment',
+    'CompanyTeam',
+    'CompanyPosition',
+    'CompanyResponsibility'
+] 

--- a/backend/src/domain/identity/entities/company.py
+++ b/backend/src/domain/identity/entities/company.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Optional, List
+from uuid import UUID
+from sqlalchemy import String, ForeignKey, Text, CHAR
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..base import IdentityBaseEntity
+
+class Company(IdentityBaseEntity):
+    """회사 엔티티"""
+    __tablename__ = "company"
+
+    business_registration_number: Mapped[str] = mapped_column(String(20), nullable=False, unique=True, 
+                                                            comment="사업자등록번호")
+    name: Mapped[str] = mapped_column(String(100), nullable=False, comment="기업명")
+    eng_name: Mapped[str] = mapped_column(String(100), nullable=False, comment="영문 기업명")
+    address: Mapped[str] = mapped_column(String(255), nullable=False)
+    phone: Mapped[str] = mapped_column(String(20), nullable=False)
+    ceo_name: Mapped[str] = mapped_column(String(100), nullable=False, comment="대표자 성명")
+    homepage_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, comment="회사 홈페이지")
+
+    # Relationships
+    users = relationship("User", back_populates="company")
+    company_users = relationship("CompanyUser", back_populates="company")
+    company_departments = relationship("CompanyDepartment", back_populates="company")
+    company_teams = relationship("CompanyTeam", back_populates="company")
+    company_positions = relationship("CompanyPosition", back_populates="company")
+    company_responsibilities = relationship("CompanyResponsibility", back_populates="company")
+    registration_requests = relationship("CompanyRegistrationRequest", back_populates="approved_company")
+    subscriptions = relationship("CompanySubscription", back_populates="company")
+
+class CompanyRegistrationRequest(IdentityBaseEntity):
+    """회사 등록 요청 엔티티"""
+    __tablename__ = "company_registration_request"
+
+    business_registration_number: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    eng_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    address: Mapped[str] = mapped_column(String(255), nullable=False)
+    phone: Mapped[str] = mapped_column(String(20), nullable=False)
+    ceo_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    homepage_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, 
+                                      comment="PENDING / APPROVED / REJECTED")
+    
+    requested_by: Mapped[UUID] = mapped_column(ForeignKey("user.id"), nullable=False)
+    approved_by: Mapped[Optional[UUID]] = mapped_column(ForeignKey("user.id"), nullable=True)
+    approved_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+    rejected_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+    reject_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    approved_company_id: Mapped[Optional[UUID]] = mapped_column(ForeignKey("company.id"), nullable=True)
+
+    # Relationships
+    requester = relationship("User", foreign_keys=[requested_by], back_populates="requested_registrations")
+    approver = relationship("User", foreign_keys=[approved_by])
+    approved_company = relationship("Company", back_populates="registration_requests") 

--- a/backend/src/domain/identity/entities/mappings.py
+++ b/backend/src/domain/identity/entities/mappings.py
@@ -1,0 +1,69 @@
+from uuid import UUID
+from sqlalchemy import String, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..base import IdentityBaseEntity
+
+class CompanyUser(IdentityBaseEntity):
+    """회사-사용자 매핑 엔티티"""
+    __tablename__ = "company_user"
+
+    company_id: Mapped[UUID] = mapped_column(ForeignKey("company.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id"), nullable=False)
+    emp_no: Mapped[str] = mapped_column(String(50), nullable=False)
+    department_id: Mapped[UUID] = mapped_column(ForeignKey("department.id"), nullable=True)
+    team_id: Mapped[UUID] = mapped_column(ForeignKey("team.id"), nullable=True)
+    responsibility_id: Mapped[UUID] = mapped_column(ForeignKey("responsibility.id"), nullable=True)
+    position_id: Mapped[UUID] = mapped_column(ForeignKey("position.id"), nullable=True)
+
+    # Relationships
+    company = relationship("Company", back_populates="company_users")
+    user = relationship("User", back_populates="company_users")
+    department = relationship("Department", back_populates="company_departments")
+    team = relationship("Team", back_populates="company_teams")
+    responsibility = relationship("Responsibility", back_populates="company_responsibilities")
+    position = relationship("Position", back_populates="company_positions")
+
+class CompanyDepartment(IdentityBaseEntity):
+    """회사-부서 매핑 엔티티"""
+    __tablename__ = "company_department"
+
+    company_id: Mapped[UUID] = mapped_column(ForeignKey("company.id"), nullable=False)
+    department_id: Mapped[UUID] = mapped_column(ForeignKey("department.id"), nullable=False)
+
+    # Relationships
+    company = relationship("Company", back_populates="company_departments")
+    department = relationship("Department", back_populates="company_departments")
+
+class CompanyTeam(IdentityBaseEntity):
+    """회사-팀 매핑 엔티티"""
+    __tablename__ = "company_team"
+
+    company_id: Mapped[UUID] = mapped_column(ForeignKey("company.id"), nullable=False)
+    team_id: Mapped[UUID] = mapped_column(ForeignKey("team.id"), nullable=False)
+
+    # Relationships
+    company = relationship("Company", back_populates="company_teams")
+    team = relationship("Team", back_populates="company_teams")
+
+class CompanyPosition(IdentityBaseEntity):
+    """회사-직위 매핑 엔티티"""
+    __tablename__ = "company_position"
+
+    company_id: Mapped[UUID] = mapped_column(ForeignKey("company.id"), nullable=False)
+    position_id: Mapped[UUID] = mapped_column(ForeignKey("position.id"), nullable=False)
+
+    # Relationships
+    company = relationship("Company", back_populates="company_positions")
+    position = relationship("Position", back_populates="company_positions")
+
+class CompanyResponsibility(IdentityBaseEntity):
+    """회사-직책 매핑 엔티티"""
+    __tablename__ = "company_responsibility"
+
+    company_id: Mapped[UUID] = mapped_column(ForeignKey("company.id"), nullable=False)
+    responsibility_id: Mapped[UUID] = mapped_column(ForeignKey("responsibility.id"), nullable=False)
+
+    # Relationships
+    company = relationship("Company", back_populates="company_responsibilities")
+    responsibility = relationship("Responsibility", back_populates="company_responsibilities") 

--- a/backend/src/domain/identity/entities/organization.py
+++ b/backend/src/domain/identity/entities/organization.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..base import OrganizationBaseEntity
+
+class Department(OrganizationBaseEntity):
+    """부서 엔티티
+    
+    Attributes:
+        id (UUID): 기본 키 (IdMixin에서 상속)
+        name (str): 부서명 (OrganizationBaseEntity에서 상속)
+    """
+    __tablename__ = "department"
+
+    # Relationships
+    company_departments = relationship("CompanyDepartment", back_populates="department")
+
+class Team(OrganizationBaseEntity):
+    """팀 엔티티
+    
+    Attributes:
+        id (UUID): 기본 키 (IdMixin에서 상속)
+        name (str): 팀명 (OrganizationBaseEntity에서 상속)
+    """
+    __tablename__ = "team"
+
+    # Relationships
+    company_teams = relationship("CompanyTeam", back_populates="team")
+
+class Position(OrganizationBaseEntity):
+    """직위 엔티티
+    
+    Attributes:
+        id (UUID): 기본 키 (IdMixin에서 상속)
+        name (str): 직위명 (OrganizationBaseEntity에서 상속)
+    """
+    __tablename__ = "position"
+
+    # Relationships
+    company_positions = relationship("CompanyPosition", back_populates="position")
+
+class Responsibility(OrganizationBaseEntity):
+    """직책 엔티티
+    
+    Attributes:
+        id (UUID): 기본 키 (IdMixin에서 상속)
+        name (str): 직책명 (OrganizationBaseEntity에서 상속)
+    """
+    __tablename__ = "responsibility"
+
+    # Relationships
+    company_responsibilities = relationship("CompanyResponsibility", back_populates="responsibility") 

--- a/backend/src/domain/identity/entities/user.py
+++ b/backend/src/domain/identity/entities/user.py
@@ -1,0 +1,24 @@
+from typing import Optional
+from uuid import UUID
+from sqlalchemy import String, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..base import IdentityBaseEntity
+
+class User(IdentityBaseEntity):
+    """사용자 엔티티"""
+    __tablename__ = "user"
+
+    emp_no: Mapped[str] = mapped_column(String(50), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    password: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    role: Mapped[str] = mapped_column(String(20), nullable=False, 
+                                    comment="USER / TEAM_MANAGER / ORG_ADMIN / SYS_ADMIN")
+    company_id: Mapped[Optional[UUID]] = mapped_column(ForeignKey("company.id"), nullable=True)
+
+    # Relationships
+    company = relationship("Company", back_populates="users")
+    company_users = relationship("CompanyUser", back_populates="user")
+    auth_tokens = relationship("AuthTokenLog", back_populates="user")
+    role_logs = relationship("UserRoleLog", back_populates="user") 


### PR DESCRIPTION
## 개요

이번 PR은 TeamOn의 identity 도메인 내 조직 및 회사 관련 엔티티/매핑 구조를 비즈니스 로직에 맞게 개선하고, 각 엔티티의 상속 및 필드 구조를 명확히 하는 데 목적이 있습니다.  
회사별 부서/팀/직위/직책 정보 관리와 사용자 일괄 업로드 시의 데이터 구조 일관성을 확보하였습니다.

---

## 주요 변경 사항 및 파일 목록

### 1. 조직 엔티티 구조 명확화  
- **변경 파일:**  
  - `backend/src/domain/identity/entities/organization.py`  
- **주요 내용:**  
  - Department, Team, Position, Responsibility 엔티티에 상속 구조 및 필드(특히 name, id) 명확히 주석화  
  - 각 엔티티가 OrganizationBaseEntity를 상속받아 name 필드를 공통적으로 사용하도록 통일

### 2. 회사-조직 매핑 테이블 구조 개선  
- **변경 파일:**  
  - `backend/src/domain/identity/entities/mappings.py`  
- **주요 내용:**  
  - company_department, company_team, company_position, company_responsibility 등 매핑 테이블을 실제 비즈니스 로직(회사별 조직 정보 관리)에 맞게 설계  
  - 각 매핑 테이블이 회사와 조직 엔티티의 id를 외래키로 참조하도록 구현

### 3. 회사 및 사용자 엔티티 관계 정비  
- **변경 파일:**  
  - `backend/src/domain/identity/entities/company.py`  
  - `backend/src/domain/identity/entities/user.py`  
- **주요 내용:**  
  - 회사와 사용자, 매핑 테이블 간의 관계(Relationship) 정의를 명확히 하여 ORM 매핑의 일관성 및 가독성 향상

### 4. 공통 베이스 및 Mixin 구조 일관성 강화  
- **변경 파일:**  
  - `backend/src/domain/identity/base.py`  
- **주요 내용:**  
  - 모든 엔티티가 DDD 원칙에 따라 IdentityBaseEntity 또는 OrganizationBaseEntity를 상속받도록 정비  
  - 공통 Audit 컬럼 및 상태 관리 컬럼은 base.py의 Mixin을 통해 일관 적용

### 5. 문서화 및 주석 보강  
- **변경 파일:**  
  - `backend/src/domain/identity/entities/organization.py`  
- **주요 내용:**  
  - 각 엔티티에 주요 필드와 상속 구조를 명확히 설명하는 docstring 추가

---

## 비즈니스 시나리오 반영

- 부서/팀/직위/직책 정보는 회사별로 관리되며, UI에서 “선택 또는 새로 추가” 방식으로 입력 가능  
- 회사 사용자는 엑셀 업로드를 통해 일괄 등록되며, 각 조직 정보는 매핑 테이블을 통해 연결됨

---

## 기타

- 추후 MSA 확장 및 유지보수성을 고려한 구조로 설계  
- 코드 일관성 및 가독성 향상

---

